### PR TITLE
Fix TabLineSel highlight

### DIFF
--- a/lua/kimbox/highlights.lua
+++ b/lua/kimbox/highlights.lua
@@ -133,7 +133,7 @@ hl.common = {
     Question = {fg = c.green},
     NormalFloat = {fg = c.fg1, bg = c.bg3}, -- Normal text in floating windows.
     TabLine = {fg = c.fg, bg = c.bg1}, -- Tab pages line, not active tab page label
-    TabLineSel = {fg = c.bg0, bg = c.fg, gui = bold}, -- Tab pages line, active tab page label
+    TabLineSel = {fg = c.bg1, bg = c.fg4, gui = bold }, -- Tab pages line, active tab page label
     -- TabLineSel = {fg = c.fg, bg = c.bg1}, -- Tab pages line, active tab page label
     -- TabLineFill = {fg = c.fg, bg = c.bg1}, -- Tab pages line, where there are no labels
     TabLineFill = {gui = "none"}, -- Tab pages line, where there are no labels


### PR DESCRIPTION
![gscreenshot_2022-11-23-135502](https://user-images.githubusercontent.com/63652620/203496295-e57d6d11-83b9-4667-8b56-96bcb8d162db.png)
Seems like I fixed it. I didn't try it on vim-airline yet. Will try this evening.